### PR TITLE
Put exclusions in order by Ruby version for easy reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,24 @@ before_install:
   - gem install bundler # https://github.com/travis-ci/travis-ci/issues/9333
 matrix:
  exclude:
+   - rvm: 1.9.3
+     gemfile: Gemfile
+   - rvm: 1.9.3
+     gemfile: gemfiles/Gemfile-rails.5.0.x
+   - rvm: 1.9.3
+     gemfile: gemfiles/Gemfile-rails.5.1.x
+   - rvm: 2.0.0
+     gemfile: Gemfile
+   - rvm: 2.0.0
+     gemfile: gemfiles/Gemfile-rails.5.0.x
+   - rvm: 2.0.0
+     gemfile: gemfiles/Gemfile-rails.5.1.x
+   - rvm: 2.1.10
+     gemfile: Gemfile
+   - rvm: 2.1.10
+     gemfile: gemfiles/Gemfile-rails.5.0.x
+   - rvm: 2.1.10
+     gemfile: gemfiles/Gemfile-rails.5.1.x
    - rvm: 2.2.10
      gemfile: gemfiles/Gemfile-rails.3.2.x
    - rvm: 2.3.7
@@ -30,24 +48,7 @@ matrix:
      gemfile: gemfiles/Gemfile-rails.3.2.x
    - rvm: 2.5.1
      gemfile: gemfiles/Gemfile-rails.3.2.x
-   - rvm: 1.9.3
-     gemfile: gemfiles/Gemfile-rails.5.0.x
-   - rvm: 2.0.0
-     gemfile: gemfiles/Gemfile-rails.5.0.x
-   - rvm: 2.1.10
-     gemfile: gemfiles/Gemfile-rails.5.0.x
-   - rvm: 1.9.3
-     gemfile: gemfiles/Gemfile-rails.5.1.x
-   - rvm: 2.0.0
-     gemfile: gemfiles/Gemfile-rails.5.1.x
-   - rvm: 2.1.10
-     gemfile: gemfiles/Gemfile-rails.5.1.x
-   - rvm: 1.9.3
-     gemfile: Gemfile
-   - rvm: 2.0.0
-     gemfile: Gemfile
-   - rvm: 2.1.10
-     gemfile: Gemfile
+
 notifications:
   email: false
   campfire:


### PR DESCRIPTION
Hey there! This is a simple PR that orders the exclusions in the Travis build matrix by Ruby and Rails versions. This makes it easier to check at a glance which exclusions there already are and if any others need to be added during future development.