### PR TITLE
Remove "rubyforge_project" from .gemspec file

### DIFF
--- a/mail_form.gemspec
+++ b/mail_form.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.test_files    = Dir["test/**/*"]
   s.require_paths = ["lib"]
 
-  s.rubyforge_project = "mail_form"
-
   s.required_ruby_version = '>= 2.4.0'
 
   s.add_dependency('actionmailer', '>= 5.0')


### PR DESCRIPTION
This option has been deprecated.